### PR TITLE
Bshouse master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ PdfLayoutManager.iml
 target/
 settings.xml
 test.pdf
+testProtectAttach.pdf

--- a/src/main/java/com/planbase/pdf/layoutmanager/PdfLayoutMgr.java
+++ b/src/main/java/com/planbase/pdf/layoutmanager/PdfLayoutMgr.java
@@ -15,7 +15,8 @@
 package com.planbase.pdf.layoutmanager;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
+import org.apache.pdfbox.pdmodel.PDDocumentNameDictionary;
+import org.apache.pdfbox.pdmodel.PDEmbeddedFilesNameTreeNode;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
@@ -932,16 +933,32 @@ public class PdfLayoutMgr {
         }
         return sB.toString();
     }
-    
-    public void protect(ProtectionPolicy policy) throws IOException {
-      doc.protect(policy);
+
+    /**
+     Addes the embedded files tree to the underlying PDDOcumentNameDictionary in PDFBox.
+     Access to this is necessary in order to "protect" a PDF file.
+     See PDDocumentNameDictionary.setEmbeddedFiles() for most of the details.
+     @since 0.5.2
+     */
+    public void setEmbeddedFilesOnDict(PDEmbeddedFilesNameTreeNode efTree) {
+        PDDocumentNameDictionary dict = new PDDocumentNameDictionary(doc.getDocumentCatalog());
+        dict.setEmbeddedFiles(efTree);
+        doc.getDocumentCatalog().setNames(dict);
     }
-    
-    public PDEmbeddedFile addEmbeddedFile(InputStream str) throws IOException {
-      return new PDEmbeddedFile(doc,str);
-    }
-    
-    public PDDocumentCatalog getDocumentCatalog() {
-      return doc.getDocumentCatalog();
-    }
+
+    /**
+     Sets the protection policy on the underlying PDDocument.
+     This marks the document to be encrypted when it is saved.
+     See the same named method on apache PDFBox PDDocument for further details.
+     Note that this is not necessarily iron-clad protection, maybe more like a hint that the document is private.
+     @since 0.5.2
+     */
+    public void protect(ProtectionPolicy policy) throws IOException { doc.protect(policy); }
+
+    /**
+     Creates a new PDFBox PDEmbeddedFile from the underlying PDDocument and the supplied InputStream.
+     This is necessary in order to "protect" a PDF file.
+     @since 0.5.2
+     */
+    public PDEmbeddedFile addEmbeddedFile(InputStream str) throws IOException { return new PDEmbeddedFile(doc,str); }
 }

--- a/src/test/java/TestManualllyProtectAttach.java
+++ b/src/test/java/TestManualllyProtectAttach.java
@@ -1,4 +1,4 @@
-// Copyright 2013-03-13 PlanBase Inc. & Glen Peterson
+// Copyright 2013-03-13 PlanBase Inc. & Glen Peterson & B. Shouse
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ import com.planbase.pdf.layoutmanager.CellStyle;
 import com.planbase.pdf.layoutmanager.LogicalPage;
 import com.planbase.pdf.layoutmanager.PdfLayoutMgr;
 import com.planbase.pdf.layoutmanager.TextStyle;
-import com.planbase.pdf.layoutmanager.XyOffset;
 
 import org.apache.pdfbox.pdmodel.PDDocumentNameDictionary;
 import org.apache.pdfbox.pdmodel.PDEmbeddedFilesNameTreeNode;
@@ -40,12 +39,7 @@ import java.awt.Color;
 
 public class TestManualllyProtectAttach {
 
-//    public static void main(String... args) throws IOException, COSVisitorException {
-//        new TestManualllyPdfLayoutMgr().testPdf();
-//    }
-
-    @Test
-    public void testProtectAttach() throws IOException {
+    @Test public void testProtectAttach() throws IOException {
         // Nothing happens without a PdfLayoutMgr.
         PdfLayoutMgr pageMgr = PdfLayoutMgr.newRgbPageMgr();
 
@@ -57,8 +51,14 @@ public class TestManualllyProtectAttach {
 
 
         // Include a simple description
-        Cell protectAttach = Cell.builder(CellStyle.DEFAULT, lp.pageWidth()-100f).textStyle(TextStyle.of(PDType1Font.HELVETICA, 12f, Color.BLACK)).addStrs("This document should be protected against writing","Check the document properties for Security.","It should be password protected with 40-bit encryption","There should also be a PNG image attached.").build();
-        XyOffset xya = lp.putCell(20f, lp.yPageTop(), protectAttach);
+        Cell protectAttach = Cell.builder(CellStyle.DEFAULT, lp.pageWidth()-100f)
+                                 .textStyle(TextStyle.of(PDType1Font.HELVETICA, 12f, Color.BLACK))
+                                 .addStrs("This document should be protected against writing",
+                                          "Check the document properties for Security.",
+                                          "It should be password protected with 40-bit encryption",
+                                          "There should also be a PNG image attached.")
+                                 .build();
+        lp.putCell(20f, lp.yPageTop(), protectAttach);
         
         lp.commit();
         
@@ -66,7 +66,7 @@ public class TestManualllyProtectAttach {
         AccessPermission ap = new AccessPermission();
         ap.setCanModify(false);
         
-        // Setup a protection policy
+        // Setup a protection policy with the password, "ownerPassword"
         StandardProtectionPolicy sp = new StandardProtectionPolicy("ownerPassword","",ap);
         
         // Apply protection

--- a/src/test/java/TestManualllyProtectAttach.java
+++ b/src/test/java/TestManualllyProtectAttach.java
@@ -17,8 +17,6 @@ import com.planbase.pdf.layoutmanager.CellStyle;
 import com.planbase.pdf.layoutmanager.LogicalPage;
 import com.planbase.pdf.layoutmanager.PdfLayoutMgr;
 import com.planbase.pdf.layoutmanager.TextStyle;
-
-import org.apache.pdfbox.pdmodel.PDDocumentNameDictionary;
 import org.apache.pdfbox.pdmodel.PDEmbeddedFilesNameTreeNode;
 import org.apache.pdfbox.pdmodel.common.filespecification.PDComplexFileSpecification;
 import org.apache.pdfbox.pdmodel.common.filespecification.PDEmbeddedFile;
@@ -27,6 +25,7 @@ import org.apache.pdfbox.pdmodel.encryption.StandardProtectionPolicy;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.junit.Test;
 
+import java.awt.Color;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -35,7 +34,6 @@ import java.io.OutputStream;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
-import java.awt.Color;
 
 public class TestManualllyProtectAttach {
 
@@ -89,21 +87,9 @@ public class TestManualllyProtectAttach {
         pf.setEmbeddedFile(ef);
         efMap.put("Picture", pf);
         efTree.setNames(efMap);
-        PDDocumentNameDictionary dict = new PDDocumentNameDictionary(pageMgr.getDocumentCatalog());
-        dict.setEmbeddedFiles(efTree);
-        pageMgr.getDocumentCatalog().setNames(dict);
+        pageMgr.setEmbeddedFilesOnDict(efTree);
 
         // All done - write it out!
-
-        // In a web application, this could be:
-        //
-        // httpServletResponse.setContentType("application/pdf") // your server may do this for you.
-        // os = httpServletResponse.getOutputStream()            // you probably have to do this
-        //
-        // Also, in a web app, you probably want name your action something.pdf and put
-        // target="_blank" on your link to the PDF download action.
-
-        // We're just going to write to a file.
         OutputStream os = new FileOutputStream("testProtectAttach.pdf");
 
         // Commit it to the output stream!


### PR DESCRIPTION
I'd like to expose as little of the underlying PDDocument as possible.  We used to expose none of it.  It does not look like we need to expose the PDDocumentCatalog at all for your test case.  So I made this change.

Then I went through all the steps to merge your changes into the master branch, update the version number, change log, JavaDoc, etc.  I typed my commit message.  My hand was hovering over the Enter key.  But I could not press it.

I have only the vaguest idea of what you are even trying to do here.  We use PdfLayoutManager in at least 2 different production projects at work.  The number of GitHub issues make me think some other people use it too.  If someone misuses any of the underlying PDFBox stuff that this change exposes, I'm going to feel obligated to help them figure it why "my" code isn't working and I have no experience using the encryption aspects of PDF.

I need 2 questions answered in order to merge this.

1. PDFBox docs suggest that when you call [PDDocument.protect()](https://pdfbox.apache.org/docs/2.0.7/javadocs/org/apache/pdfbox/pdmodel/PDDocument.html#protect(org.apache.pdfbox.pdmodel.encryption.ProtectionPolicy)) the *entire document* will be encrypted when it's written out.  If it's encrypted, how come I can open it without a password?  To me, Encrypted does not mean "encrypted on Windows" or "encrypted with the Adobe reader."  It means encrypted Everywhere.  Your text in the document suggests it's write-protected.  Does that mean that just the password is encrypted?  If so, then we should tell PDFBox that their documentation is misleading.

2. How come I can't see the image?  Is this another thing that only works on the Adobe PDF reader?  I acknowledge that *might* be good enough, but it doesn't feel right to me.  Evince has handled every PDF I've ever thrown at it.  Most of my career has been web development and "Works on one browser" is not the same as "Works on all browsers."

I'm sorry, but I can't merge this without understanding it better.  If I'd worked closely with you for years, maybe you could just swear to me that it works, and I would merge it.  But I don't know who you are or anything about you.  I can't clearly see this working on my system so I need more data.

Maybe a better unit test?  Maybe walk me through with a screen shot from xxd and link to the relevant section of the PDF spec?  The hex dump and spec route is extremely time consuming, so I hope you can think of a better way...